### PR TITLE
Helpful note for running scan-build

### DIFF
--- a/_posts/2020-05-20-arm-cortexm-with-llvm-clang.md
+++ b/_posts/2020-05-20-arm-cortexm-with-llvm-clang.md
@@ -179,6 +179,13 @@ scan-build: 8 bugs found.
 scan-build: Run 'scan-view /var/folders/dm/b0yt' to examine bug reports.
 ```
 
+`scan-build` uses `gcc` by default on some platforms.
+If this happens, you may see error messages related to unrecognized command line options and the `===GCC Compiler Detected===` message.
+Set the compiler for `scan-build` to clang with the `--use-cc` and `--use-c++` options:
+```bash
+$ scan-build --use-cc=clang --use-c++=clang make
+```
+
 #### core.NullDereference Checker
 
 ```c


### PR DESCRIPTION
Hi, this blog post was really useful but missing this information took me way too long to research! I have seen this issue with clang-10 (as used in the post) and clang-16 (latest). This issue is mentioned in the comments of the post and the `gcc` default on non-Darwin platforms is in the docs (https://clang-analyzer.llvm.org/scan-build.html) if you search for "Darwin".

This would have saved me a lot of time and presumably will help people in the future!